### PR TITLE
fix: export types as named exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "description": "Wallet address validator for Bitcoin and other Altcoins.",
   "main": "dist/ramp-crypto-address-validator.umd.js",
   "module": "dist/ramp-crypto-address-validator.es5.js",
-  "typings": "dist/types/wallet_address_validator.d.ts",
+  "typings": "dist/wallet_address_validator.d.ts",
   "files": [
     "dist/**"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Ramp Network <contact@ramp.network>",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "files": [
     "dist/**"
   ],
-  "version": "1.0.1",
+  "version": "1.0.0",
   "author": "Ramp Network <contact@ramp.network>",
   "publishConfig": {
     "access": "public"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 import * as Currencies from "./currencies.types";
-import * as HashFunctions from "./hashFunctions.types";
-import * as NetTypes from "./net.types";
-import * as Validator from "./validator.types";
+import { HashFunctions } from "./hashFunctions.types";
+import { NetTypes } from "./net.types";
+import { IValidator } from "./validator.types";
 import * as Validators from "./validators.types";
 
-export { Currencies, HashFunctions, NetTypes, Validator, Validators };
+export type { Currencies, HashFunctions, NetTypes, IValidator, Validators };

--- a/src/wallet_address_validator.ts
+++ b/src/wallet_address_validator.ts
@@ -1,5 +1,11 @@
 import currencies from "./currencies";
-import { IValidator } from "./types/validator.types";
+import {
+  Currencies,
+  HashFunctions,
+  IValidator,
+  NetTypes,
+  Validators,
+} from "./types";
 
 const DEFAULT_CURRENCY_NAME = "bitcoin";
 
@@ -40,3 +46,4 @@ const walletAddressValidator: IValidator = {
 };
 
 export default walletAddressValidator;
+export type { Currencies, HashFunctions, NetTypes, IValidator, Validators };


### PR DESCRIPTION
Types can now be imported using named imports